### PR TITLE
Fix TriggerView not calling measure callback

### DIFF
--- a/src/TriggeringView.js
+++ b/src/TriggeringView.js
@@ -61,6 +61,7 @@ class TriggeringView extends Component {
     return (
       <View
         ref={(view) => { this.containerView = view; }}
+        collapsable={false}
         {...viewProps}
       >
         { this.props.children }


### PR DESCRIPTION
`view.measure` does only work on Android, if view has `collapsable: false`. See https://github.com/facebook/react-native/issues/3282#issuecomment-253992505

Currently possible with setting `collapsable={false}` on `<TriggerView>` ifself, since the view-props get passed through. But should be in the Component itself.