### PR TITLE
Fix a faulty setState call when container could be unmounted in future

### DIFF
--- a/src/ImageHeaderScrollView.js
+++ b/src/ImageHeaderScrollView.js
@@ -199,7 +199,7 @@ class ImageHeaderScrollView extends Component<Props, State> {
     }
     this.container.measureInWindow((x, y) => {
       if (this.container) {
-        this.setState(() => ({ pageY: y }))
+        this.setState(() => ({ pageY: y }));
       }
     });
   };

--- a/src/ImageHeaderScrollView.js
+++ b/src/ImageHeaderScrollView.js
@@ -197,7 +197,11 @@ class ImageHeaderScrollView extends Component<Props, State> {
     if (!this.container) {
       return;
     }
-    this.container.measureInWindow((x, y) => this.setState(() => ({ pageY: y })));
+    this.container.measureInWindow((x, y) => {
+			if (this.container) {
+				this.setState(() => ({ pageY: y }))
+			}
+		});
   };
 
   onScroll = (e: *) => {

--- a/src/ImageHeaderScrollView.js
+++ b/src/ImageHeaderScrollView.js
@@ -198,10 +198,10 @@ class ImageHeaderScrollView extends Component<Props, State> {
       return;
     }
     this.container.measureInWindow((x, y) => {
-			if (this.container) {
-				this.setState(() => ({ pageY: y }))
-			}
-		});
+      if (this.container) {
+        this.setState(() => ({ pageY: y }))
+      }
+    });
   };
 
   onScroll = (e: *) => {


### PR DESCRIPTION
Hello, we have been using this great library but there is a issue when you use `HeaderImageScrollView` inside a `View` that also has `onLayout` callback attached then rotating the device will cause the error to come up in React-Native warning box stating that `setState` can't be used on unmounted component.

This is happening because:  
```
onContainerLayout = () => {
    if (!this.container) {
      return;
    }
    this.container.measureInWindow((x, y) => this.setState(() => ({ pageY: y })));
};
```

The actual callback with `this.setState` call might indeed happen when the component is unmounted.
Therefore I have added additional guard inside that callback to make sure that  `setState` won't fire if `container` does not exist anymore.