### PR TITLE
UNSAFE_ applied to TriggeringView to mute the warnings

### DIFF
--- a/src/TriggeringView.js
+++ b/src/TriggeringView.js
@@ -68,14 +68,14 @@ class TriggeringView extends Component<Props, State> {
     this.initialPageY = 0;
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     if (!this.context.scrollY) {
       return;
     }
     this.listenerId = this.context.scrollY.addListener(this.onScroll);
   }
 
-  componentWillReceiveProps(nextProps: Props, nextContext: Context) {
+  UNSAFE_componentWillReceiveProps(nextProps: Props, nextContext: Context) {
     if (!this.context.scrollY) {
       return;
     }


### PR DESCRIPTION
TriggeringView were showing warnings on ReactNative 0.60 and up.
Muted for now by applying UNSAFE_ to componentWillMount and componentWillReceiveProps.